### PR TITLE
Follow field naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ enable it by appending `C1222::log_identification_service=T` to the `zeek` comma
 | version                | int            | Reference Version Number                                  |
 | revision               | int            | Reference Revision Number                                 |
 | security_mechanism     | string         | Universal ID of the security mechanism supported          |
-| nbrSession_supported   | bool           | Node supports session-based communication                 |
+| nbr_session_supported   | bool           | Node supports session-based communication                 |
 | sessionless_supported  | bool           | Supports use of read and write outside of session         |
 | device_class           | string         | Universal device identifier                               |
 | device_identity_format | int            | Device identity encoding format flag                      |

--- a/scripts/c1222_processing.zeek
+++ b/scripts/c1222_processing.zeek
@@ -389,10 +389,10 @@ event C1222::ResponseOkIdent(c: connection, is_orig: bool, ident: Zeek_C1222::Re
                 break;
             case C1222_ENUMS::IdentFeatureTags_SESSION_CTRL:
                 if(feature$sessionCtrl$sessionCtrl$nbrSessionSupported == 0){
-                    ident_log$nbrSession_supported = F;
+                    ident_log$nbr_session_supported = F;
                 }
                 else{
-                    ident_log$nbrSession_supported = T;
+                    ident_log$nbr_session_supported = T;
                 }
                 ident_log$sessionless_supported = feature$sessionCtrl$sessionCtrl$sessionlessSupported;
                 break;

--- a/scripts/c1222_types.zeek
+++ b/scripts/c1222_types.zeek
@@ -82,7 +82,7 @@ export {
         version: int &optional &log;
         revision: int &optional &log;
         security_mechanism: string &optional &log;
-        nbrSession_supported: bool &optional &log;
+        nbr_session_supported: bool &optional &log;
         sessionless_supported: bool &optional &log;
         device_class: string &optional &log;
         device_identity_format: int &optional &log;


### PR DESCRIPTION
The field currently named "nbrSession_supported" does not follow snake case naming conventions and is renamed to "        nbr_session_supported". 

This change was tested by installing the parser user zkg in zeek compiled with both clang and gcc. Bith compile cleanly and unit tests pass without updates. 
