### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Note that even the default logs have optional toggles to disable them - they are
 
 ## Installation
 
+### Requirements
+* Zeek install >=6.2.0
+
 ### Package Manager
 
 This script is available as a package for [Zeek Package Manager](https://docs.zeek.org/projects/package-manager/en/stable/index.html). Zeek includes Spicy support by default as of [v6.0.0](https://github.com/zeek/zeek/releases/tag/v6.0.0).


### PR DESCRIPTION
## 🗣 Description ##

Added minimum Zeek requirement to the readme for successful compilation.

## 💭 Motivation and context ##
#5 demonstrated compilation failing on Zeek versions older than 6.2.0. At this moment there are no plans to provide greater backwards compatibility. 

## 🧪 Testing ##

Confirmed by attempting to install using zkg on Zeek versions above and below 6.2.0
